### PR TITLE
move deletion of awaiting job to ready instead of inside done

### DIFF
--- a/lib/Job/Async/Worker/Redis.pm
+++ b/lib/Job/Async/Worker/Redis.pm
@@ -238,7 +238,6 @@ sub trigger {
                     my ($id, $queue, @details) = @_;
                     try {
                         $log->debugf('And we have an event on %s', $queue);
-                        delete $self->{awaiting_job};
                         if($id) {
                             $log->tracef('Had task from queue, pending now %d', 0 + keys %{$self->{pending_jobs}});
                             $self->incoming_job->emit([ $id, $queue ]);
@@ -255,7 +254,9 @@ sub trigger {
                     $self->loop->later($self->curry::weak::trigger) unless $self->stopping_future->is_ready;
                 }),
                 $self->stopping_future->without_cancel
-            );
+            )->on_ready(sub {
+                delete $self->{awaiting_job};
+            });
         };
     } catch {
         $log->errorf('Failed to trigger job handling on %s - %s', $queue, $@);


### PR DESCRIPTION
With current code, if request times out and we mark the job as done and
the worker starts processing a new job then we get future lost error
when we are processing a new job

error trace with `PERL_DEBUG_FUTURE` set as 1 and with `-d:Confess` flag

```
IO::Async::Future=HASH(0x15f715e0) was constructed at /home/git/regentmarkets/cpan/local/lib/perl5/Job/Async/Worker/Redis.pm line 253 and was lost near /home/git/regentmarkets/cpan/local/lib/perl5/Job/Async/Worker/Redis.pm line 239 before it was ready.
 at /home/git/regentmarkets/cpan/local/lib/perl5/Future.pm line 285.
	Future::DESTROY_debug(IO::Async::Future=HASH(0x15f715e0)) called at /home/git/regentmarkets/cpan/local/lib/perl5/Job/Async/Worker/Redis.pm line 239
	eval {...} called at /home/git/regentmarkets/cpan/local/lib/perl5/Job/Async/Worker/Redis.pm line 239
	Job::Async::Worker::Redis::__ANON__[/home/git/regentmarkets/cpan/local/lib/perl5/Job/Async/Worker/Redis.pm:249]("a04fd294-c326-45c6-9399-28ef0eaf79ec") called at /home/git/regentmarkets/cpan/local/lib/perl5/Future.pm line 459
	Future::_mark_ready(IO::Async::Future=HASH(0x15f47670), "done") called at /home/git/regentmarkets/cpan/local/lib/perl5/Future.pm line 597
	Future::done(IO::Async::Future=HASH(0x15f47670), "a04fd294-c326-45c6-9399-28ef0eaf79ec") called at /home/git/regentmarkets/cpan/local/lib/perl5/Net/Async/Redis.pm line 336
	Net::Async::Redis::on_message(Net::Async::Redis=HASH(0x15f20070), "a04fd294-c326-45c6-9399-28ef0eaf79ec") called at /home/git/regentmarkets/cpan/local/lib/perl5/curry.pm line 4
```